### PR TITLE
Upwork refactor

### DIFF
--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -248,7 +248,7 @@ export default class App {
 const app = new App();
 
 process.on('unhandledRejection', (reason, promise) => {
-  console.log(2, reason, promise, true)
+  console.log(reason, promise)
   logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
 });
 

--- a/src/app/App.ts
+++ b/src/app/App.ts
@@ -248,6 +248,7 @@ export default class App {
 const app = new App();
 
 process.on('unhandledRejection', (reason, promise) => {
+  console.log(2, reason, promise, true)
   logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
 });
 

--- a/src/config/validateEnv.ts
+++ b/src/config/validateEnv.ts
@@ -40,7 +40,7 @@ const {
 } = process.env;
 
 const isDev = process.env.NODE_ENV === "development";
-const defaultRedisHost = "redis";
+const defaultRedisHost = "127.0.0.1";
 const defaultRedisPort = "6379";
 
 const broadcasterBalanceThreshold = parseInt(BROADCASTER_BALANCE_THRESHOLD as string);

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -10,7 +10,7 @@ const connectionString =
 
 export const connectDb = async (env: string) => {
   if (env !== "production") {
-    set("debug", true);
+    // set("debug", true);
   }
 
   logger.info("Connecting to the database...", { connectionString });

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -10,7 +10,7 @@ const connectionString =
 
 export const connectDb = async (env: string) => {
   if (env !== "production") {
-    // set("debug", true);
+    set("debug", true);
   }
 
   logger.info("Connecting to the database...", { connectionString });

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ function setupExitHandlers() {
   });
 
   process.on("unhandledRejection", async (reason, promise) => {
-    console.log(reason, promise, true)
+    console.log(reason, promise)
     logger.error("Unhandled Rejection at:", promise, "reason:", reason);
     await gracefulShutdown('UNHANDLED_REJECTION');
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,9 @@ import AppQueueFactory from "queue/queue/AppQueueFactory";
 import { testRedisConnection } from "queue/queue/AppQueueFactory";
 import appConfig from "@config/index";
 
-logger.info("Starting bot...");
-logger.info(`Redis configuration: host=${appConfig.redisHost}, port=${appConfig.redisPort}`);
+// There are some duplicated loggers in the codebase. We can remove the following loggers:
+// logger.info("Starting bot...");
+// logger.info(`Redis configuration: host=${appConfig.redisHost}, port=${appConfig.redisPort}`);
 
 setupExitHandlers();
 
@@ -40,6 +41,7 @@ function setupExitHandlers() {
   });
 
   process.on("unhandledRejection", async (reason, promise) => {
+    console.log(reason, promise, true)
     logger.error("Unhandled Rejection at:", promise, "reason:", reason);
     await gracefulShutdown('UNHANDLED_REJECTION');
   });

--- a/src/queue/jobs/validators/ValAllInfoCheckerJob.ts
+++ b/src/queue/jobs/validators/ValAllInfoCheckerJob.ts
@@ -81,11 +81,17 @@ export const initValAllInfoCheckerQueue = async () => {
         }
 
         try {
-          if (appConfig.axelarVoterAddress == voterAddress && dbValidator) {
+          if (voterAddress && appConfig.axelarVoterAddress == voterAddress && dbValidator) {
             await sendEvmChainSupportRegistrationNotification(
               dbValidator,
               valEvmSupportedChains
             );
+          } else {
+            if(!voterAddress) {
+              logger.info(
+                `Voter address not found for operator address: ${operatorAddress}`
+              );
+            }
           }
         } catch (error) {
           logger.error(

--- a/src/queue/queue/AppQueueFactory.ts
+++ b/src/queue/queue/AppQueueFactory.ts
@@ -8,7 +8,7 @@ const { redisHost, redisPort } = appConfig;
 const redisClient = new Redis({
   host: appConfig.redisHost,
   port: appConfig.redisPort,
-  maxRetriesPerRequest: 3,
+  maxRetriesPerRequest: null,
   enableReadyCheck: false,
   retryStrategy(times) {
     const delay = Math.min(times * 50, 2000);
@@ -136,7 +136,8 @@ export async function testRedisConnection() {
   const client = new Redis({
     host: appConfig.redisHost,
     port: appConfig.redisPort,
-    maxRetriesPerRequest: 1,
+    maxRetriesPerRequest: null,
+    enableReadyCheck: false,
     retryStrategy: () => null,
     connectTimeout: 5000,
   });

--- a/src/services/rest/AxelarLCDQueryService.ts
+++ b/src/services/rest/AxelarLCDQueryService.ts
@@ -1,6 +1,7 @@
 import appConfig from "@/config/index";
 import { AxiosService } from "@/services/rest/axios/AxiosService";
 import { RegisterProxyGetResponse } from "@/services/rest/interfaces/tx/RegisterProxyGetResponse";
+import { logger } from "@/utils/logger";
 
 export class AxelarLCDQueryService {
   restClient: AxiosService;
@@ -25,16 +26,18 @@ export class AxelarLCDQueryService {
 
   public async getValidatorVoterAddress(
     operatorAddress: string
-  ): Promise<string> {
+  ): Promise<string | null> {
     const response = await this.getValidatorRegisterProxyInfo(operatorAddress);
     if (response?.txs.length === 0) {
-      return Promise.reject(new Error("No RegisterProxy tx found"));
+      logger.warn(`No RegisterProxy tx found for ${operatorAddress}`);
+      return null;
     }
 
     const firstMessage = response?.txs?.[0]?.body?.messages?.[0];
 
     if (!firstMessage) {
-      return Promise.reject(new Error("No message found in RegisterProxy tx"));
+      logger.warn(`No messages found for ${operatorAddress}`);
+      return null;
     }
 
     return firstMessage.proxy_addr as string;

--- a/src/ws/client/AxelarWsClient.ts
+++ b/src/ws/client/AxelarWsClient.ts
@@ -17,7 +17,7 @@ export class AxelarWsClient {
 
   constructor() {
     const url = mainnetAxelarWsUrls[0];
-    console.log(url);
+    // console.log(url);
 
     this.ws = new WebSocket(url, {
       headers: {


### PR DESCRIPTION
# Changes
## Redis
- defaultRedist host changed **redis** => **127.0.0.1** due to local error
- Fixed unhandled rejection
- - Error: Using a redis instance with enableReadyCheck or maxRetriesPerRequest for bclient/subscriber is not permitted
- - `enableReadyCheck` and `maxRetriesPerRequest` set to **null**
## Voter address checker
- Added warning to ensure the errors
## Refactoring
- Some log operations are duplicated. Commented some of them. We will look to other statements in next next steps